### PR TITLE
Handle Abort command correctly

### DIFF
--- a/extra/resources/coqdocjs.js
+++ b/extra/resources/coqdocjs.js
@@ -72,7 +72,7 @@ function isProofStart(s){
 }
 
 function isProofEnd(s){
-  return isVernacStart(["Qed", "Admitted", "Defined"], s);
+  return isVernacStart(["Qed", "Admitted", "Defined", "Abort"], s);
 }
 
 function proofStatus(){


### PR DESCRIPTION
Previously

```
Goal False.
Abort.

Goal True.
  tauto.
Qed.
```
was displayed as
``` 
Goal False.
```
because `Abort.` was not recognised as proof end.