### PR TITLE
Check whether subscript is present in config

### DIFF
--- a/extra/resources/coqdocjs.js
+++ b/extra/resources/coqdocjs.js
@@ -6,7 +6,13 @@ function replace(s){
   if (m = s.match(/^(.+)'/)) {
     return replace(m[1])+"'";
   } else if (m = s.match(/^([A-Za-z]+)_?(\d+)$/)) {
-    return replace(m[1])+m[2].replace(/\d/g, function(d){return coqdocjs.subscr[d]});
+    return replace(m[1])+m[2].replace(/\d/g, function(d){
+      if (coqdocjs.subscr.hasOwnProperty(d)) {
+        return coqdocjs.subscr[d];
+      } else {
+        return d;
+      }
+    });
   } else if (coqdocjs.repl.hasOwnProperty(s)){
     return coqdocjs.repl[s]
   } else {


### PR DESCRIPTION
Otherwise missing subscripts (eg, from changing the config to an empty object) are replaced with `undefined`.