### PR TITLE
Optimize replInTextNodes

### DIFF
--- a/extra/resources/coqdocjs.js
+++ b/extra/resources/coqdocjs.js
@@ -26,10 +26,11 @@ function toArray(nl){
 
 function replInTextNodes() {
   coqdocjs.replInText.forEach(function(toReplace){
-    toArray(document.getElementsByClassName("code")).concat(toArray(document.getElementsByClassName("inlinecode"))).forEach(function(elem){
-      toArray(elem.childNodes).forEach(function(node){
+      document.querySelectorAll('.code, .inlinecode').forEach(function(elem){
+      elem.childNodes.forEach(function(node){
         if (node.nodeType != Node.TEXT_NODE) return;
         var fragments = node.textContent.split(toReplace);
+	if (fragments.length === 1) return;
         node.textContent = fragments[fragments.length-1];
         for (var k = 0; k < fragments.length - 1; ++k) {
           node.parentNode.insertBefore(document.createTextNode(fragments[k]),node);


### PR DESCRIPTION
I have some very large files that I'd like to use coqdocjs for, but the resulting files take too long to render. After running the profiler, I found the main culprits are `replInTextNodes` and `foldProofs`.

`replInTextNodes` is unnecessarily inefficient  because it mutates the `textContent` field even when the keywords to be replaced don't exist (i.e. when the `split` function returns an array of size 1). Now the code simply leaves the DOM unchanged whenever possible.

I tried optimizing `foldProofs`, but the `appendChild` overhead is much harder to get rid of, which makes me wonder if the right thing to do is to add a static pass to preprocess the  html files so js doesn't have to modify the dom as often.